### PR TITLE
bugfix: lock lodash version to 3.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "lodash": "^3.10.1"
+    "lodash": "3.10.1"
   }
 }


### PR DESCRIPTION
修复：将依赖的 lodash 版本锁定为 3.10.1